### PR TITLE
Add interactive soccer drill designer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Soccer Drill Designer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <h1>Soccer Drill Designer</h1>
+
+      <section>
+        <h2>Players &amp; Staff</h2>
+        <form id="player-form" class="stack" autocomplete="off">
+          <label class="input-block">
+            <span>Label</span>
+            <input type="text" id="player-label" placeholder="Player #" />
+          </label>
+          <label class="input-block">
+            <span>Shape</span>
+            <select id="player-shape">
+              <option value="circle">Circle</option>
+              <option value="square">Square</option>
+              <option value="triangle">Triangle</option>
+              <option value="rhombus">Rhombus</option>
+            </select>
+          </label>
+          <label class="input-block">
+            <span>Color</span>
+            <input type="color" id="player-color" value="#2b6cb0" />
+          </label>
+          <label class="input-block">
+            <span>Role</span>
+            <select id="player-role">
+              <option value="">Player</option>
+              <option value="GK">Goalkeeper</option>
+              <option value="Coach">Coach</option>
+            </select>
+          </label>
+          <button type="submit" class="primary">Add player</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Training equipment</h2>
+        <div class="equipment-grid" id="equipment-buttons">
+          <button type="button" data-type="cone">Cone</button>
+          <button type="button" data-type="marker">Marker</button>
+          <button type="button" data-type="small-goal">Small goal</button>
+          <button type="button" data-type="big-goal">Big goal</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Actions</h2>
+        <div class="actions-grid" id="action-buttons">
+          <button type="button" data-action="run" class="active">Run</button>
+          <button type="button" data-action="dribble">Dribble</button>
+          <button type="button" data-action="pass">Pass</button>
+          <button type="button" data-action="shoot">Shoot</button>
+          <button type="button" data-action="none">Move items</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>Animation</h2>
+        <button type="button" id="animate-button" class="secondary">Play drill</button>
+        <button type="button" id="clear-lines" class="secondary">Clear lines</button>
+        <button type="button" id="reset-field" class="secondary">Reset field</button>
+      </section>
+    </aside>
+
+    <main class="workspace">
+      <div class="field-wrapper">
+        <div id="field" class="field" tabindex="0">
+          <svg id="field-overlay" xmlns="http://www.w3.org/2000/svg"></svg>
+        </div>
+      </div>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,325 @@
+const field = document.getElementById('field');
+const svg = document.getElementById('field-overlay');
+const playerForm = document.getElementById('player-form');
+const equipmentButtons = document.getElementById('equipment-buttons');
+const actionButtons = document.getElementById('action-buttons');
+const animateButton = document.getElementById('animate-button');
+const clearLinesButton = document.getElementById('clear-lines');
+const resetFieldButton = document.getElementById('reset-field');
+
+const ACTION_META = {
+  run: { className: 'action-run', color: '#ffffff', duration: 1200 },
+  dribble: { className: 'action-dribble', color: '#ffd166', duration: 1500 },
+  pass: { className: 'action-pass', color: '#38bdf8', duration: 900 },
+  shoot: { className: 'action-shoot', color: '#ef4444', duration: 800 },
+};
+
+const EQUIPMENT_META = {
+  cone: { label: 'Cone', emoji: '🟠', scale: 0.95 },
+  marker: { label: 'Marker', emoji: '⭕', scale: 0.85 },
+  'small-goal': { label: 'Small goal', emoji: '🥅', scale: 1.05 },
+  'big-goal': { label: 'Big goal', emoji: '🥅', scale: 1.2 },
+};
+
+let activeAction = 'run';
+let isDrawing = false;
+let currentLine = null;
+let currentLineMeta = null;
+const lines = [];
+
+setupSvgMarkers();
+observeFieldSize();
+
+playerForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const label = document.getElementById('player-label').value.trim();
+  const shape = document.getElementById('player-shape').value;
+  const color = document.getElementById('player-color').value;
+  const role = document.getElementById('player-role').value;
+
+  const player = document.createElement('div');
+  player.classList.add('drill-item', `shape-${shape}`);
+  player.style.setProperty('--item-color', color);
+
+  const text = document.createElement('span');
+  text.textContent = label || defaultLabelForRole(role) || 'P';
+  player.appendChild(text);
+
+  if (role) {
+    const badge = document.createElement('span');
+    badge.textContent = role;
+    badge.className = 'badge';
+    player.appendChild(badge);
+  }
+
+  placeOnField(player);
+  makeDraggable(player);
+  playerForm.reset();
+  document.getElementById('player-color').value = color;
+});
+
+equipmentButtons.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-type]');
+  if (!button) return;
+
+  const type = button.dataset.type;
+  const meta = EQUIPMENT_META[type];
+  if (!meta) return;
+
+  const equipment = document.createElement('div');
+  equipment.classList.add('drill-item', 'equipment');
+  equipment.dataset.type = type;
+  equipment.style.setProperty('--scale', meta.scale || 1);
+  equipment.setAttribute('aria-label', meta.label);
+
+  const icon = document.createElement('span');
+  icon.textContent = meta.emoji;
+  equipment.appendChild(icon);
+
+  placeOnField(equipment);
+  makeDraggable(equipment);
+});
+
+actionButtons.addEventListener('click', (event) => {
+  const button = event.target.closest('button[data-action]');
+  if (!button) return;
+
+  const action = button.dataset.action;
+  activeAction = action;
+
+  actionButtons.querySelectorAll('button').forEach((btn) => {
+    btn.classList.toggle('active', btn === button);
+  });
+});
+
+field.addEventListener('pointerdown', (event) => {
+  if (activeAction === 'none') return;
+  if (event.target.closest('.drill-item')) return;
+
+  const { x, y } = getRelativePoint(event);
+  const line = createSvgLine(x, y, x, y);
+  const meta = ACTION_META[activeAction];
+  if (!meta) {
+    isDrawing = false;
+    return;
+  }
+  isDrawing = true;
+  line.classList.add(meta.className);
+  line.dataset.action = activeAction;
+
+  svg.appendChild(line);
+  currentLine = line;
+  currentLineMeta = { action: activeAction, start: { x, y } };
+
+  event.preventDefault();
+});
+
+field.addEventListener('pointermove', (event) => {
+  if (!isDrawing || !currentLine) return;
+  const { x, y } = getRelativePoint(event);
+  currentLine.setAttribute('x2', x);
+  currentLine.setAttribute('y2', y);
+});
+
+const finishLine = () => {
+  if (!isDrawing || !currentLine) return;
+
+  const x1 = parseFloat(currentLine.getAttribute('x1'));
+  const y1 = parseFloat(currentLine.getAttribute('y1'));
+  const x2 = parseFloat(currentLine.getAttribute('x2'));
+  const y2 = parseFloat(currentLine.getAttribute('y2'));
+  const distance = Math.hypot(x2 - x1, y2 - y1);
+
+  if (distance < 12) {
+    currentLine.remove();
+  } else {
+    const stored = {
+      element: currentLine,
+      action: currentLineMeta.action,
+      start: { x: x1, y: y1 },
+      end: { x: x2, y: y2 },
+    };
+    lines.push(stored);
+  }
+
+  currentLine = null;
+  currentLineMeta = null;
+  isDrawing = false;
+};
+
+field.addEventListener('pointerup', finishLine);
+field.addEventListener('pointerleave', finishLine);
+field.addEventListener('pointercancel', finishLine);
+
+animateButton.addEventListener('click', async () => {
+  if (!lines.length) return;
+  animateButton.disabled = true;
+  await playLinesSequentially(lines);
+  animateButton.disabled = false;
+});
+
+clearLinesButton.addEventListener('click', () => {
+  lines.splice(0, lines.length);
+  svg.querySelectorAll('line').forEach((line) => line.remove());
+});
+
+resetFieldButton.addEventListener('click', () => {
+  lines.splice(0, lines.length);
+  svg.querySelectorAll('*').forEach((node) => node.remove());
+  setupSvgMarkers();
+  field.querySelectorAll('.drill-item').forEach((item) => item.remove());
+});
+
+function placeOnField(element) {
+  const rect = field.getBoundingClientRect();
+  const x = rect.width / 2;
+  const y = rect.height / 2;
+  element.style.left = `${x}px`;
+  element.style.top = `${y}px`;
+  field.appendChild(element);
+}
+
+function makeDraggable(element) {
+  element.addEventListener('pointerdown', (event) => {
+    if (activeAction !== 'none') return;
+    event.preventDefault();
+    element.setPointerCapture(event.pointerId);
+
+    const rect = field.getBoundingClientRect();
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const initialX = parseFloat(element.style.left) || rect.width / 2;
+    const initialY = parseFloat(element.style.top) || rect.height / 2;
+
+    const move = (ev) => {
+      const deltaX = ev.clientX - startX;
+      const deltaY = ev.clientY - startY;
+      let nextX = initialX + deltaX;
+      let nextY = initialY + deltaY;
+      nextX = clamp(nextX, 0, rect.width);
+      nextY = clamp(nextY, 0, rect.height);
+      element.style.left = `${nextX}px`;
+      element.style.top = `${nextY}px`;
+    };
+
+    const up = (ev) => {
+      element.releasePointerCapture(ev.pointerId);
+      element.removeEventListener('pointermove', move);
+      element.removeEventListener('pointerup', up);
+      element.removeEventListener('pointercancel', up);
+    };
+
+    element.addEventListener('pointermove', move);
+    element.addEventListener('pointerup', up);
+    element.addEventListener('pointercancel', up);
+  });
+}
+
+function createSvgLine(x1, y1, x2, y2) {
+  const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+  line.setAttribute('x1', x1);
+  line.setAttribute('y1', y1);
+  line.setAttribute('x2', x2);
+  line.setAttribute('y2', y2);
+  line.setAttribute('stroke-linecap', 'round');
+  return line;
+}
+
+function getRelativePoint(event) {
+  const rect = field.getBoundingClientRect();
+  return {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top,
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function defaultLabelForRole(role) {
+  if (role === 'GK') return 'GK';
+  if (role === 'Coach') return 'C';
+  return '';
+}
+
+async function playLinesSequentially(items) {
+  for (const item of items) {
+    await animateLine(item);
+  }
+}
+
+function animateLine(lineMeta) {
+  return new Promise((resolve) => {
+    const meta = ACTION_META[lineMeta.action];
+    const { element } = lineMeta;
+    const length = element.getTotalLength();
+    const startTime = performance.now();
+    const duration = meta.duration;
+    element.classList.add('is-animating');
+
+    const dot = document.createElement('div');
+    dot.className = `line-dot ${lineMeta.action}`;
+    field.appendChild(dot);
+
+    const step = (now) => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+      const point = element.getPointAtLength(length * progress);
+      dot.style.left = `${point.x}px`;
+      dot.style.top = `${point.y}px`;
+
+      if (progress < 1) {
+        requestAnimationFrame(step);
+      } else {
+        dot.remove();
+        element.classList.remove('is-animating');
+        resolve();
+      }
+    };
+
+    requestAnimationFrame(step);
+  });
+}
+
+function setupSvgMarkers() {
+  const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
+  const markers = [
+    { id: 'arrow-run', color: '#ffffff' },
+    { id: 'arrow-dribble', color: '#ffd166' },
+    { id: 'arrow-pass', color: '#38bdf8' },
+    { id: 'arrow-shoot', color: '#ef4444' },
+  ];
+
+  markers.forEach(({ id, color }) => {
+    const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker');
+    marker.setAttribute('id', id);
+    marker.setAttribute('markerWidth', '10');
+    marker.setAttribute('markerHeight', '10');
+    marker.setAttribute('refX', '7');
+    marker.setAttribute('refY', '5');
+    marker.setAttribute('orient', 'auto');
+    marker.setAttribute('markerUnits', 'strokeWidth');
+
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+    path.setAttribute('fill', color);
+    marker.appendChild(path);
+    defs.appendChild(marker);
+  });
+
+  svg.appendChild(defs);
+}
+
+function observeFieldSize() {
+  const resize = () => {
+    const rect = field.getBoundingClientRect();
+    svg.setAttribute('viewBox', `0 0 ${rect.width} ${rect.height}`);
+    svg.setAttribute('width', rect.width);
+    svg.setAttribute('height', rect.height);
+  };
+
+  resize();
+  const observer = new ResizeObserver(resize);
+  observer.observe(field);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,344 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 16px;
+  --bg: #f5f5f8;
+  --panel-bg: #ffffff;
+  --border: #d0d4dd;
+  --accent: #2b6cb0;
+  --text: #1f2933;
+  --muted: #5f6c7b;
+  --field-green: #2d7a40;
+  --field-light: #3e9153;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+h1, h2 {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+}
+
+h1 {
+  font-size: 1.5rem;
+}
+
+h2 {
+  font-size: 1rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.app {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+}
+
+.sidebar {
+  background: var(--panel-bg);
+  border-right: 1px solid var(--border);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.input-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.input-block input,
+.input-block select {
+  padding: 0.5rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  font: inherit;
+  background: #fff;
+}
+
+button {
+  cursor: pointer;
+  border-radius: 0.7rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 12px rgb(0 0 0 / 0.08);
+}
+
+button.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+button.secondary {
+  width: 100%;
+  margin-bottom: 0.35rem;
+}
+
+.equipment-grid,
+.actions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.actions-grid button.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.workspace {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.field-wrapper {
+  width: min(100%, 960px);
+  aspect-ratio: 105 / 68;
+  background: linear-gradient(var(--field-green), var(--field-light));
+  border-radius: 1.5rem;
+  box-shadow: 0 25px 60px rgb(0 0 0 / 0.15);
+  position: relative;
+  overflow: hidden;
+  border: 12px solid #0f3b1e;
+}
+
+.field {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  user-select: none;
+  touch-action: none;
+}
+
+.field::before,
+.field::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 3px solid rgba(255, 255, 255, 0.7);
+  border-radius: 1.25rem;
+  pointer-events: none;
+}
+
+.field::after {
+  border-left: none;
+  border-right: none;
+  border-top: 0;
+  border-bottom: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  background:
+    radial-gradient(circle at 50% 50%, transparent 23%, rgba(255, 255, 255, 0.9) 23%, rgba(255, 255, 255, 0.9) 24%, transparent 24%),
+    radial-gradient(circle at 25% 50%, transparent 19%, rgba(255, 255, 255, 0.9) 19%, rgba(255, 255, 255, 0.9) 20%, transparent 20%),
+    radial-gradient(circle at 75% 50%, transparent 19%, rgba(255, 255, 255, 0.9) 19%, rgba(255, 255, 255, 0.9) 20%, transparent 20%);
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
+  mix-blend-mode: screen;
+}
+
+#field-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.drill-item {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  transform: translate(-50%, -50%) scale(var(--scale, 1));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #fff;
+  background: var(--item-color, #2b6cb0);
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.5);
+  cursor: grab;
+  touch-action: none;
+  clip-path: circle(50% at 50% 50%);
+  z-index: 2;
+}
+
+.drill-item span {
+  pointer-events: none;
+}
+
+.drill-item:active {
+  cursor: grabbing;
+}
+
+.drill-item .badge {
+  position: absolute;
+  bottom: -1.4rem;
+  background: rgba(17, 24, 39, 0.85);
+  color: #fff;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.shape-circle {
+  clip-path: circle(50% at 50% 50%);
+}
+
+.shape-square {
+  border-radius: 0.5rem;
+  clip-path: inset(0 round 0.5rem);
+}
+
+.shape-triangle {
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.shape-rhombus {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0 50%);
+}
+
+.equipment {
+  background: rgba(255, 255, 255, 0.15);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  font-size: 1.75rem;
+  clip-path: inset(0 round 0.75rem);
+}
+
+.equipment[data-type="small-goal"],
+.equipment[data-type="big-goal"] {
+  font-size: 1.35rem;
+}
+
+.line-dot {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  box-shadow: 0 4px 10px rgb(0 0 0 / 0.35);
+  z-index: 3;
+}
+
+.line-dot.run {
+  background: #ffffff;
+  border: 2px solid #0f172a;
+}
+
+.line-dot.dribble {
+  background: #ffd166;
+}
+
+.line-dot.pass {
+  background: #38bdf8;
+}
+
+.line-dot.shoot {
+  background: #ef4444;
+}
+
+svg line,
+svg path {
+  pointer-events: none;
+}
+
+line.is-animating {
+  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.6));
+}
+
+.action-run {
+  stroke: #ffffff;
+  stroke-width: 4;
+  stroke-dasharray: 10 6;
+  marker-end: url(#arrow-run);
+}
+
+.action-dribble {
+  stroke: #ffd166;
+  stroke-width: 4;
+  stroke-dasharray: 4 6;
+  marker-end: url(#arrow-dribble);
+}
+
+.action-pass {
+  stroke: #38bdf8;
+  stroke-width: 4;
+  stroke-dasharray: 16 8;
+  marker-end: url(#arrow-pass);
+}
+
+.action-shoot {
+  stroke: #ef4444;
+  stroke-width: 5;
+  stroke-linecap: round;
+  marker-end: url(#arrow-shoot);
+}
+
+.line-head {
+  fill: none;
+  stroke: inherit;
+  stroke-width: inherit;
+}
+
+@media (max-width: 960px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: relative;
+    width: 100%;
+    height: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .workspace {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page soccer drill designer UI with controls for players, equipment, and actions
- style the football pitch, draggable items, and animated action lines with tailored CSS
- implement drag-and-drop players, add training props, draw action lines, and play an animated sequence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d446e6d394832a9b12e38cb1f77690